### PR TITLE
Fixed loading of pub/private key, will fix ssh_config if key exists

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -12,9 +12,13 @@ RUN curl -J -L -o /tmp/prt.zip https://github.com/wnielson/Plex-Remote-Transcode
     rm -rf /tmp/Plex-Remote-Transcoder-master && \
     cd /
 
+USER root
+
 ENV SLAVE_IP=slave_ip \
     SLAVE_PORT=22 \
     SLAVE_USER=plex \
     MASTER_IP=master_ip
+
+RUN chown plex:plex /usr/lib/plexmediaserver -R
 
 COPY root/ /

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,4 +1,5 @@
-FROM plexinc/pms-docker:latest
+ARG PLEX_VERSION
+FROM plexinc/pms-docker:${PLEX_VERSION}
 MAINTAINER Simon Hartcher <github.com/deevus>
 
 RUN apt-get update -q && \
@@ -12,13 +13,9 @@ RUN curl -J -L -o /tmp/prt.zip https://github.com/wnielson/Plex-Remote-Transcode
     rm -rf /tmp/Plex-Remote-Transcoder-master && \
     cd /
 
-USER root
-
 ENV SLAVE_IP=slave_ip \
     SLAVE_PORT=22 \
     SLAVE_USER=plex \
     MASTER_IP=master_ip
-
-RUN chown plex:plex /usr/lib/plexmediaserver -R
 
 COPY root/ /

--- a/master/root/etc/cont-init.d/61-prt-master-install
+++ b/master/root/etc/cont-init.d/61-prt-master-install
@@ -10,3 +10,5 @@ echo $MASTER_IP | prt install
 # current versions of prt/plex require Library in this location
 ln -s /config/Library /var/lib/plexmediaserver/Library
 
+chown plex:plex /config/.prt.conf
+chmod uga+rw /config/.prt.conf

--- a/master/root/etc/cont-init.d/62-ssh-keygen
+++ b/master/root/etc/cont-init.d/62-ssh-keygen
@@ -7,14 +7,7 @@ then
     printf "StrictHostKeyChecking no\n" >> /etc/ssh/ssh_config
     #update the ssh config and set the pub/private keys
     sed -i 's+#   IdentityFile ~+IdentityFile /config+' /etc/ssh/ssh_config
-    #printf "IdentityFile /config/.ssh/identity
-    ##IdentityFile /config/.ssh/id_rsa
-    #IdentityFile /config/.ssh/id_dsa
-    #IdentityFile /config/.ssh/id_ecdsa
-    #IdentityFile /config/.ssh/id_ed25519
     printf "GlobalKnownHostsFile /config/.ssh/known_hosts" >> /etc/ssh/ssh_config
-
-
 
     printf "Host *\n    ControlPath ~/.ssh/controlmasters/%%r@%%h:%%p\n    ControlMaster auto\n    ControlPersist 2h\n" > /config/.ssh/config
     mkdir -p /config/.ssh/controlmasters

--- a/master/root/etc/cont-init.d/62-ssh-keygen
+++ b/master/root/etc/cont-init.d/62-ssh-keygen
@@ -5,10 +5,22 @@ then
     mkdir -p /config/.ssh
     ssh-keygen -P '' -f /config/.ssh/id_rsa
     printf "StrictHostKeyChecking no\n" >> /etc/ssh/ssh_config
+    #update the ssh config and set the pub/private keys
+    sed -i 's+#   IdentityFile ~+IdentityFile /config+' /etc/ssh/ssh_config
+    #printf "IdentityFile /config/.ssh/identity
+    ##IdentityFile /config/.ssh/id_rsa
+    #IdentityFile /config/.ssh/id_dsa
+    #IdentityFile /config/.ssh/id_ecdsa
+    #IdentityFile /config/.ssh/id_ed25519
+    printf "GlobalKnownHostsFile /config/.ssh/known_hosts" >> /etc/ssh/ssh_config
+
+
 
     printf "Host *\n    ControlPath ~/.ssh/controlmasters/%%r@%%h:%%p\n    ControlMaster auto\n    ControlPersist 2h\n" > /config/.ssh/config
     mkdir -p /config/.ssh/controlmasters
 
     chown -R plex.plex /config/.ssh
     chmod 600 /config/.ssh/config /config/.ssh/id_rsa /config/.ssh/id_rsa.pub
+
+    chown -R plex:plex /usr/lib/plexmediaserver
 fi

--- a/master/root/etc/cont-init.d/62-ssh-keygen
+++ b/master/root/etc/cont-init.d/62-ssh-keygen
@@ -12,8 +12,8 @@ then
     printf "Host *\n    ControlPath ~/.ssh/controlmasters/%%r@%%h:%%p\n    ControlMaster auto\n    ControlPersist 2h\n" > /config/.ssh/config
     mkdir -p /config/.ssh/controlmasters
 
-    chown -R plex.plex /config/.ssh
-    chmod 600 /config/.ssh/config /config/.ssh/id_rsa /config/.ssh/id_rsa.pub
+    chown -R plex:plex /config/.ssh
+    #chmod 600 /config/.ssh/config /config/.ssh/id_rsa /config/.ssh/id_rsa.pub
 
-    chown -R plex:plex /usr/lib/plexmediaserver
+    #chown -R plex:plex /usr/lib/plexmediaserver
 fi

--- a/master/root/etc/cont-init.d/63-ssh-config
+++ b/master/root/etc/cont-init.d/63-ssh-config
@@ -3,10 +3,10 @@ if grep -q 'StrictHostKeyChecking no'  /etc/ssh/ssh_config;
 then
     echo "ssh_config contains everything we need"
 else
-    printf "StrictHostKeyChecking no\n" >> /etc/ssh/ssh_config
+    #printf "StrictHostKeyChecking no\n" >> /etc/ssh/ssh_config
     #update the ssh config and set the pub/private keys
-    sed -i 's+#   IdentityFile ~+IdentityFile /config+' /etc/ssh/ssh_config
-    printf "GlobalKnownHostsFile /config/.ssh/known_hosts\n" >> /etc/ssh/ssh_config
+    #sed -i 's+#   IdentityFile ~+IdentityFile /config+' /etc/ssh/ssh_config
+    #printf "GlobalKnownHostsFile /config/.ssh/known_hosts\n" >> /etc/ssh/ssh_config
 fi
 
 

--- a/master/root/etc/cont-init.d/63-ssh-config
+++ b/master/root/etc/cont-init.d/63-ssh-config
@@ -1,0 +1,17 @@
+#!/usr/bin/with-contenv bash
+if grep -q 'StrictHostKeyChecking no'  /etc/ssh/ssh_config;
+then
+    echo "ssh_config contains everything we need"
+else
+    printf "StrictHostKeyChecking no\n" >> /etc/ssh/ssh_config
+    #update the ssh config and set the pub/private keys
+    sed -i 's+#   IdentityFile ~+IdentityFile /config+' /etc/ssh/ssh_config
+    #printf "IdentityFile /config/.ssh/identity
+    ##IdentityFile /config/.ssh/id_rsa
+    #IdentityFile /config/.ssh/id_dsa
+    #IdentityFile /config/.ssh/id_ecdsa
+    #IdentityFile /config/.ssh/id_ed25519
+    printf "GlobalKnownHostsFile /config/.ssh/known_hosts\n" >> /etc/ssh/ssh_config
+fi
+
+

--- a/master/root/etc/cont-init.d/63-ssh-config
+++ b/master/root/etc/cont-init.d/63-ssh-config
@@ -6,11 +6,6 @@ else
     printf "StrictHostKeyChecking no\n" >> /etc/ssh/ssh_config
     #update the ssh config and set the pub/private keys
     sed -i 's+#   IdentityFile ~+IdentityFile /config+' /etc/ssh/ssh_config
-    #printf "IdentityFile /config/.ssh/identity
-    ##IdentityFile /config/.ssh/id_rsa
-    #IdentityFile /config/.ssh/id_dsa
-    #IdentityFile /config/.ssh/id_ecdsa
-    #IdentityFile /config/.ssh/id_ed25519
     printf "GlobalKnownHostsFile /config/.ssh/known_hosts\n" >> /etc/ssh/ssh_config
 fi
 

--- a/master/root/etc/cont-init.d/64-fix-plex-crypto
+++ b/master/root/etc/cont-init.d/64-fix-plex-crypto
@@ -1,0 +1,8 @@
+#!/usr/bin/with-contenv bash
+
+if [ -f /usr/lib/plexmediaserver/lib/libcrypto.so.1.0.0 ]
+then
+    echo "I can't remove /usr/lib/plexmediaserver/lib/libcrypto.so.1.0.0 or plex stops, but remove after 1st run"
+else
+    echo "No bad crypto in this dir so another will be used."
+fi

--- a/master/root/etc/cont-init.d/64-fix-plex-crypto
+++ b/master/root/etc/cont-init.d/64-fix-plex-crypto
@@ -1,8 +1,0 @@
-#!/usr/bin/with-contenv bash
-
-if [ -f /usr/lib/plexmediaserver/lib/libcrypto.so.1.0.0 ]
-then
-    echo "I can't remove /usr/lib/plexmediaserver/lib/libcrypto.so.1.0.0 or plex stops, but remove after 1st run"
-else
-    echo "No bad crypto in this dir so another will be used."
-fi

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -27,4 +27,6 @@ COPY root/ /
 RUN rm -rf /etc/services.d/plex && \
     sed -i -e 's;/config:/bin/false;/config:/bin/bash;g' /etc/passwd
 
+USER plex
+
 EXPOSE 22

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -1,4 +1,5 @@
-FROM plexinc/pms-docker:latest
+ARG PLEX_VERSION
+FROM plexinc/pms-docker:${PLEX_VERSION}
 MAINTAINER Simon Hartcher <github.com/deevus>
 
 RUN apt-get update -q && \
@@ -26,7 +27,5 @@ RUN mkdir /var/run/sshd
 COPY root/ /
 RUN rm -rf /etc/services.d/plex && \
     sed -i -e 's;/config:/bin/false;/config:/bin/bash;g' /etc/passwd
-
-USER plex
 
 EXPOSE 22

--- a/slave/root/etc/cont-init.d/10-ssh-init
+++ b/slave/root/etc/cont-init.d/10-ssh-init
@@ -9,11 +9,25 @@ then
         echo "ERROR: public key file not found in /config/.ssh"
         exit 1
     else
-        echo "INFO: importing public key" && \
-        # import public key
-        cat /config/.ssh/id_rsa.pub > /etc/ssh/plex/authorized_keys && \
+        echo "INFO: importing public key" 
+        # import public key - this working because on a 2nd slave, it wont yet exist and can trigger some functions
+        cat /config/.ssh/id_rsa.pub > /etc/ssh/plex/authorized_keys
+        if [ ! -f /config/.ssh/authorized_keys ]
+        then
+            cat /config/.ssh/id_rsa.pub > /config/.ssh/authorized_keys
+            chown david:david /config/.ssh -R
+        else
+            echo "Authorized keys already contained id_rsa.pub"
+        fi
+            
+        #echo "Setting Authorized Files to /etc/ssh/plex/authorized_keys"
+        #echo "AuthorizedKeysFile /etc/ssh/plex/authorized_keys" > /etc/ssh/sshd_config 
+        echo "Setting Authorized Files to /config/.ssh/authorized_keys"
+        echo "AuthorizedKeysFile /config/.ssh/authorized_keys" > /etc/ssh/sshd_config
+
         # enable plex user ssh login
         usermod -p '*' plex
+        #chmod 600 /config/.ssh -R
     fi
 else
     echo "INFO: Public key already loaded. Skipping..."


### PR DESCRIPTION
So made some edits to the key loading, since it seemed to try and use /root/.ssh, so I forced everyone (via ssh_config) to use /config/.ssh 

The other change that seems to be needed is that  /usr/lib/plexmediaserver/lib/libcrypto.so.1.0.0 needs to be removed (in the plex dir).  But I can't remove it as part of startup, as plex complains.

But if you remove it once plex is running, then all works.
Been an interesting exercise.